### PR TITLE
Improve README for modular docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,46 @@
 # Code Documentation Skeleton
 [![Validate Docs](https://github.com/example/code-doc-skeleton/actions/workflows/validate-docs.yml/badge.svg)](https://github.com/example/code-doc-skeleton/actions/workflows/validate-docs.yml)
 
-Este repositorio provee una base para documentar proyectos de software siguiendo la filosofía **documentation-first**.
+Este repositorio contiene una estructura modular para escribir y publicar documentación técnica.
+Se basa en **MkDocs** y está pensado para proyectos que siguen la filosofía *documentation‑first*.
 
-## Uso
+## ¿Para qué sirve?
+- Mantener separada la documentación en módulos temáticos.
+- Facilitar la colaboración mediante plantillas reutilizables.
+- Publicar un sitio estático con GitHub Pages.
 
-1. Instalar dependencias:
+## Levantar el sitio local
+1. Instalar las dependencias:
    ```bash
    python -m pip install -r requirements.txt
    ```
-2. Levantar el sitio de documentación localmente:
+2. Ejecutar el servidor de MkDocs:
    ```bash
    mkdocs serve
    ```
+   El sitio estará disponible en `http://localhost:8000`.
 
-La documentación fuente se encuentra en `docs/` y el sitio generado se publica en `public/` mediante GitHub Pages.
+## Publicar en GitHub Pages
+1. Genera el sitio estático:
+   ```bash
+   mkdocs build
+   ```
+   Los archivos se crean en la carpeta `public/`.
+2. Publica el contenido de `public/` en la rama **gh-pages** o habilita GitHub Pages en esa carpeta.
+
+## ¿Qué contiene cada carpeta?
+- **docs/**: documentación fuente organizada por temas (flujos de usuarios, reglas de negocio, APIs, etc.).
+- **templates/**: archivos base para crear nuevas secciones de documentación.
+- **public/**: salida generada por `mkdocs build`; es la que se publica en GitHub Pages.
+- **mkdocs.yml**: configuración del sitio y del menú de navegación.
+
+## Cómo usar los templates
+1. Copia el archivo deseado de `templates/` a la ubicación apropiada dentro de `docs/`.
+   Por ejemplo:
+   ```bash
+   cp templates/TEMPLATE-api.md docs/apis/nueva-api.md
+   ```
+2. Rellena los campos del template con la información de tu proyecto.
+3. Agrega la nueva página al menú editando `mkdocs.yml` si es necesario.
+
+Con esta estructura podrás mantener tu documentación organizada y lista para publicarse.


### PR DESCRIPTION
## Summary
- rewrite README with instructions for MkDocs
- document GitHub Pages publishing
- describe directory structure and template usage

## Testing
- `pip install -r requirements.txt`
- `mkdocs build --strict`

------
https://chatgpt.com/codex/tasks/task_e_686f20abcc888320914404f0f03c706c