### PR TITLE
Add deploy workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,28 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install mkdocs mkdocs-material
+      - name: Build site
+        run: mkdocs build
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./site
+          commit_message: "deploy: auto-update site from main"


### PR DESCRIPTION
## Summary
- deploy documentation from `main` on push

## Testing
- `pip install -r requirements.txt`
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_686f2f0df61c83209f019dd4dcea25be