### PR TITLE
Fix deploy workflow settings

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -18,7 +21,7 @@ jobs:
         run: |
           pip install mkdocs mkdocs-material
       - name: Build site
-        run: mkdocs build
+        run: mkdocs build --strict
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
## Summary
- run deploy workflow on pushes to `main`
- set required write permission
- build docs with `mkdocs build --strict`

## Testing
- `mkdocs build --strict`

------
https://chatgpt.com/codex/tasks/task_e_686f3318cdac8320967cdd4d102c0866