### PR TITLE
Improve README and docs overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Se basa en **MkDocs** y está pensado para proyectos que siguen la filosofía *d
 
 Con esta estructura podrás mantener tu documentación organizada y lista para publicarse.
 
+## Configurar tu proyecto
+1. Edita `mkdocs.yml` para actualizar `site_name` y `repo_url`.
+2. Personaliza los colores y características del tema en la sección `theme`.
+3. Agrega tus páginas a la clave `nav` para que aparezcan en la navegación.
+
+
 ## Publicar la documentación
 
 Para compilar y publicar el sitio:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,12 @@
 # Documentación del Proyecto
 
 Bienvenido a la documentación. Esta plantilla sigue la filosofía **documentation-first**. Describe los flujos funcionales, reglas de negocio y detalles técnicos antes de implementar el código.
+En esta guía encontrarás ejemplos de:
+
+- [Flujos de usuario](flujo-usuarios/login.md).
+- [Reglas de negocio](reglas-negocio/autenticacion.md).
+- [APIs](apis/login-api.md).
+- [Cambios recientes](cambios/2025-07-09-feature-login-social.md).
+
+Adapta o amplía estas secciones según las necesidades de tu proyecto.
+


### PR DESCRIPTION
## Summary
- add a project configuration section to README
- expand `docs/index.md` with navigation links

## Testing
- `pip install -r requirements.txt`
- `mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_e_686f36549fa883208920ad609d052ffc