### PR TITLE
Add force_orphan option to docs deploy

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,4 +28,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
           publish_dir: ./site
+          force_orphan: true
           commit_message: "deploy: auto-update site from main"


### PR DESCRIPTION
## Summary
- ensure GitHub Pages deploy overwrites branch history

## Testing
- `pip install -r requirements.txt`
- `mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_e_686f39f543e883208e0c2465f79c77a9